### PR TITLE
Update `ProblemDetailsExceptionInterface` to extend `Throwable`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Versions 0.3.0 and prior were released as "weierophinney/problem-details".
 
 ### Changed
 
-- Nothing.
+- [#5](https://github.com/mezzio/mezzio-problem-details/pull/5) updates the `ProblemDetailsExceptionInterface` to explicitly extend `Throwable`, forcing users to extend an `Exception` type in implementations. As using it outside that context was never intended, the maintainers do not consider this a BC break.
 
 ### Deprecated
 

--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~1.0.0",
+        "phpspec/prophecy": "^1.8.0",
         "phpunit/phpunit": "^7.0.1"
     },
     "autoload": {

--- a/docs/book/exception.md
+++ b/docs/book/exception.md
@@ -10,8 +10,9 @@ To facilitate this, we provide an interface, `ProblemDetailsExceptionInterface`:
 namespace Mezzio\ProblemDetails\Exception;
 
 use JsonSerializable;
+use Throwable;
 
-interface ProblemDetailsExceptionInterface extends JsonSerializable
+interface ProblemDetailsExceptionInterface extends JsonSerializable, Throwable
 {
     public function getStatus() : int;
 

--- a/src/Exception/ProblemDetailsExceptionInterface.php
+++ b/src/Exception/ProblemDetailsExceptionInterface.php
@@ -11,11 +11,12 @@ declare(strict_types=1);
 namespace Mezzio\ProblemDetails\Exception;
 
 use JsonSerializable;
+use Throwable;
 
 /**
  * Defines an exception type for generating Problem Details.
  */
-interface ProblemDetailsExceptionInterface extends JsonSerializable
+interface ProblemDetailsExceptionInterface extends JsonSerializable, Throwable
 {
     public function getStatus() : int;
 

--- a/test/Exception/ProblemDetailsExceptionInterfaceTest.php
+++ b/test/Exception/ProblemDetailsExceptionInterfaceTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace MezzioTest\ProblemDetails\Exception;
 
+use Exception;
 use Mezzio\ProblemDetails\Exception\CommonProblemDetailsExceptionTrait;
 use Mezzio\ProblemDetails\Exception\ProblemDetailsExceptionInterface;
 use PHPUnit\Framework\TestCase;
@@ -35,7 +36,7 @@ class ProblemDetailsExceptionTest extends TestCase
             $this->title,
             $this->type,
             $this->additional
-        ) implements ProblemDetailsExceptionInterface {
+        ) extends Exception implements ProblemDetailsExceptionInterface {
             use CommonProblemDetailsExceptionTrait;
 
             public function __construct(int $status, string $detail, string $title, string $type, array $additional)

--- a/test/ProblemDetailsResponseFactoryTest.php
+++ b/test/ProblemDetailsResponseFactoryTest.php
@@ -199,7 +199,7 @@ class ProblemDetailsResponseFactoryTest extends TestCase
 
     public function testCreateResponseFromThrowableWillPullDetailsFromProblemDetailsExceptionInterface() : void
     {
-        $e = $this->prophesize(RuntimeException::class)->willImplement(ProblemDetailsExceptionInterface::class);
+        $e = $this->prophesize(ProblemDetailsExceptionInterface::class);
         $e->getStatus()->willReturn(400);
         $e->getDetail()->willReturn('Exception details');
         $e->getTitle()->willReturn('Invalid client request');
@@ -443,7 +443,7 @@ class ProblemDetailsResponseFactoryTest extends TestCase
 
     public function testRenderWithMalformedUtf8Sequences(): void
     {
-        $e = $this->prophesize(RuntimeException::class)->willImplement(ProblemDetailsExceptionInterface::class);
+        $e = $this->prophesize(ProblemDetailsExceptionInterface::class);
         $e->getStatus()->willReturn(400);
         $e->getDetail()->willReturn('Exception details');
         $e->getTitle()->willReturn('Invalid client request');


### PR DESCRIPTION
This patch modifies `ProblemDetailsExceptionInterface` to explicitly extend `Throwable`. Since the intention was always for users to implement the interface as part of an `Exception` implementation, this solidifies that contract.

Fixes #4