### PR TITLE
Synchronize `site_description` with `composer` and github repository description

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,7 +11,7 @@ nav:
         - "Not Found Handler": not-found-handler.md
         - "Default Types": default-types.md
 site_name: mezzio-problem-details
-site_description: 'PSR-7 Problem Details for HTTP API responses and middleware'
+site_description: 'Problem Details for PSR-7 HTTP APIs addressing the RFC 7807 standard'
 repo_url: 'https://github.com/mezzio/mezzio-problem-details'
 extra:
     project: Mezzio


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | yes
| QA            | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

In #23, we've referenced the RFC 7807 standard without updating the `site_description` for our documentation.

----

> What happens if these 3 sources do not match?

This description is important because it is often the first more detailed statement of what the package does or what it is useful for. In the current case, the two references "PSR-7" and "RFC 7807" are not only descriptive but also explicitly advertising.

The descriptions for the following outputs are fetched from different places:

* https://packagist.org/?query=problem%20details
* https://github.com/search?l=PHP&q=problem+details&type=Repositories
* https://github.com/mezzio
* https://docs.mezzio.dev/#api
* https://docs.mezzio.dev/mezzio-problem-details/
* …

_Originally posted by @froschdesign in https://github.com/mezzio/mezzio-problem-details/issues/23#issuecomment-1028936740_
